### PR TITLE
Support for status_code in different stream types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tmp
 .yardoc
 _yardoc
 doc/
+.idea/*

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 
 gem "activesupport"
 gem "terminal-notifier"
-gem "tcp_timeout"
+gem "tcp_timeout", github: 'lann/tcp-timeout-ruby'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem "activesupport"
 gem "terminal-notifier"
+gem "tcp_timeout"

--- a/lib/shoutout.rb
+++ b/lib/shoutout.rb
@@ -1,5 +1,6 @@
 require "uri"
 require "socket"
+require 'tcp_timeout'
 
 require "shoutout/version"
 require "shoutout/util"

--- a/lib/shoutout/headers.rb
+++ b/lib/shoutout/headers.rb
@@ -3,9 +3,10 @@ module Shoutout
     def self.parse(raw_headers)
       headers = {}
       raw_headers.split("\r\n").each do |line|
-        break if line == "\r\n" || line == ""
         key, value = line.chomp.split(":", 2)
-        headers[key.strip] = value.strip
+        if key != nil || value != nil
+            headers[key.strip] = value.strip
+        end
       end
 
       new(headers)

--- a/lib/shoutout/headers.rb
+++ b/lib/shoutout/headers.rb
@@ -4,7 +4,7 @@ module Shoutout
       headers = {}
       raw_headers.split("\r\n").each do |line|
         key, value = line.chomp.split(":", 2)
-        headers[key] = value
+        headers[key.strip] = value.strip
       end
 
       new(headers)

--- a/lib/shoutout/headers.rb
+++ b/lib/shoutout/headers.rb
@@ -4,7 +4,7 @@ module Shoutout
       headers = {}
       raw_headers.split("\r\n").each do |line|
         key, value = line.chomp.split(":", 2)
-        if key != nil || value != nil
+        if key != nil && value != nil
             headers[key.strip] = value.strip
         end
       end

--- a/lib/shoutout/headers.rb
+++ b/lib/shoutout/headers.rb
@@ -2,9 +2,9 @@ module Shoutout
   class Headers < Hash
     def self.parse(raw_headers)
       headers = {}
-      raw_headers.split($/).each do |line|
+      raw_headers.split("\r\n").each do |line|
         key, value = line.chomp.split(":", 2)
-        headers[key.strip] = value.strip
+        headers[key] = value
       end
 
       new(headers)

--- a/lib/shoutout/headers.rb
+++ b/lib/shoutout/headers.rb
@@ -3,6 +3,7 @@ module Shoutout
     def self.parse(raw_headers)
       headers = {}
       raw_headers.split("\r\n").each do |line|
+        break if line == "\r\n" || line == ""
         key, value = line.chomp.split(":", 2)
         headers[key.strip] = value.strip
       end

--- a/lib/shoutout/metadata.rb
+++ b/lib/shoutout/metadata.rb
@@ -1,6 +1,12 @@
 module Shoutout
   class Metadata < Hash
     def self.parse(raw_metadata)
+      match = raw_metadata.match(/(StreamTitle.*;)/)
+      if match != nil
+        raw_metadata = match[1]
+      else
+        raw_metadata = ""
+      end
       metadata = {}
       raw_metadata.split(";").each do |key_value_pair|
         key, value = key_value_pair.split("=", 2)

--- a/lib/shoutout/metadata.rb
+++ b/lib/shoutout/metadata.rb
@@ -1,12 +1,6 @@
 module Shoutout
   class Metadata < Hash
     def self.parse(raw_metadata)
-      match = raw_metadata.match(/(StreamTitle.*;)/)
-      if match != nil
-        raw_metadata = match[1]
-      else
-        raw_metadata = ""
-      end
       metadata = {}
       raw_metadata.split(";").each do |key_value_pair|
         key, value = key_value_pair.split("=", 2)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,7 +38,6 @@ module Shoutout
 
       # Read status line
       status_line = @socket.read(15)
-      print "\r\n\r\n" + status_line + "\r\n\r\n"
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -143,7 +142,6 @@ module Shoutout
         lines = @socket.read(512)
         #lines = lines.split("\r\n\r\n").first
         @headers = Headers.parse(lines)
-        print @headers.inspect + "\r\n\r\n"
       end
 
       def read_metadata
@@ -158,7 +156,6 @@ module Shoutout
 
           data = @socket.read(metadata_length) || raise(EOFError)
           raw_metadata = data.unpack("A*")[0]
-          print "\r\n\r\n metadata?: " + raw_metadata + "\r\n\r\n"
           @metadata = Metadata.parse(raw_metadata)
           
           report_metadata_change(@metadata)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -36,27 +36,9 @@ module Shoutout
       @socket = TCPSocket.new(uri.host, uri.port)
       @socket.puts send_header_request(uri.path)
 
-      # Read status line
-      status_line = @socket.gets
-      status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)[2].to_i
-
       @connected = true
 
       read_headers
-
-      if status_code >= 300 && status_code < 400 && headers[:location]
-        disconnect
-
-        @url = URI.join(uri, headers[:location]).to_s
-
-        return connect
-      end
-
-      unless status_code >= 200 && status_code < 300
-        disconnect
-
-        return false
-      end
 
       unless metadata_interval
         disconnect

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,7 +34,7 @@ module Shoutout
 
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.puts send_header_request(uri.path)
+      @socket.puts send_header_request(uri.path, uri.host)
 
       @connected = true
 
@@ -99,10 +99,8 @@ module Shoutout
       true
     end
 
-    def send_header_request(address)
-        return "GET / HTTP/1.1\r\nHost: #{address}\r\nConnection: close\r\n" +
-               "icy-metadata: 1\r\ntransferMode.dlna.org: Streaming\n\r\nHEAD / HTTP/1.1\r\n" +
-               "Host: #{address}\r\n" + "User-Agent: DirbleScrobbler\n\r\n";
+    def send_header_request(address, host)
+        return "GET #{address} HTTP/1.1\r\nAccept-Encoding: identity\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nConnection: close\r\nUser-Agent: iTunes/9.1.1\r\n\r\n";
     end
 
     private

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -147,21 +147,12 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          if(@first == true)
-            newmeta_int = metadata_interval - 256
-            @first = false
-          else
-            newmeta_int = metadata_interval
-          end
-          data = @socket.read(newmeta_int) || raise(EOFError)
+          data = @socket.read(metadata_interval + 255) || raise(EOFError)
+          raw_data = data.unpack("A*")[0]
+          match = raw_data.match(/(StreamTitle.*;)/)
+          next if match.nil?
 
-          data = @socket.read(1) || raise(EOFError)
-          metadata_length = data.unpack("c")[0] * 16
-          next if metadata_length == 0
-
-          data = @socket.read(metadata_length) || raise(EOFError)
-          raw_metadata = data.unpack("A*")[0]
-          @metadata = Metadata.parse(raw_metadata)
+          @metadata = Metadata.parse(match[1])
           
           report_metadata_change(@metadata)
         end

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -48,6 +48,11 @@ module Shoutout
         status_code = false
       end
 
+
+      @connected = true
+
+      read_headers
+
       if status_code != false && status_code >= 300 && status_code < 400 && headers[:location]
         disconnect
 
@@ -56,9 +61,6 @@ module Shoutout
         return connect
       end
 
-      @connected = true
-
-      read_headers
 
       unless metadata_interval
         disconnect

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -140,7 +140,7 @@ module Shoutout
 
     private
       def read_headers
-        lines = @socket.read(1024)
+        lines = @socket.read(512)
         #lines = lines.split("\r\n\r\n").first
         @headers = Headers.parse(lines)
         print @headers.inspect + "\r\n\r\n"

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -42,7 +42,11 @@ module Shoutout
       begin
         status_code = status_line.match(/\AICY ([0-9]{3})/)[1].to_i
       rescue NoMethodError
-        status_code = 200
+        begin
+            status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
+        rescue NoMethodError
+            status_code = 200
+        end
       end
 
       @connected = true

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -40,7 +40,11 @@ module Shoutout
 
       # Read status line
       status_line = @socket.gets
-      status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
+      begin
+        status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
+      rescue NoMethodError
+        status_code = 200 #custom streams who doesn't send icy 200 OK will be 200 as default, if not it will send a exception anyway
+      end
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -92,7 +92,9 @@ module Shoutout
 
       @socket.close if @socket && !@socket.closed?
       @socket = nil
-      Thread.kill(@read_metadata_thread)
+      if @read_metadata_thread != nil
+        Thread.kill(@read_metadata_thread)
+      end
       if @last_metadata_change_thread != nil
         Thread.kill(@last_metadata_change_thread)
       end

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -1,3 +1,4 @@
+require 'tcp_timeout'
 module Shoutout
   class Stream
     include QuickAccess

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -140,7 +140,8 @@ module Shoutout
 
     private
       def read_headers
-        lines = @socket.read(1624)
+        lines = @socket.read(1024)
+        #lines = lines.split("\r\n\r\n").first
         @headers = Headers.parse(lines)
         print @headers.inspect + "\r\n\r\n"
       end

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -149,8 +149,7 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          newmeta_int = metadata_interval - 256
-          data = @socket.read(newmeta_int) || raise(EOFError)
+          data = @socket.read(metadata_interval) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)
           metadata_length = data.unpack("c")[0] * 16

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -1,3 +1,4 @@
+require 'tcp_timeout'
 module Shoutout
   class Stream
     include QuickAccess
@@ -31,13 +32,13 @@ module Shoutout
 
     def connect
       return false if @connected
-      print "conencting to #{@url}"
       uri = URI.parse(@url)
-      @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.puts send_header_request(uri.path, uri.host)
+      
+      @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
+      @socket.write(send_header_request(uri.path, uri.host))
 
       # Read status line
-      status_line = @socket.gets
+      status_line = @socket.read()
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,10 +34,7 @@ module Shoutout
 
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.puts "GET #{uri.path} HTTP/1.0"
-      @socket.puts "User-Agent: iTunes/9.1.1"
-      @socket.puts "icy-metadata: 1"
-      @socket.puts
+      @socket.write send_header_request(uri.path)
 
       # Read status line
       status_line = @socket.gets
@@ -70,6 +67,12 @@ module Shoutout
       @read_metadata_thread = Thread.new(&method(:read_metadata))
 
       true
+    end
+
+    def send_header_request(address)
+        return "GET / HTTP/1.1\r\nHost: #{address}\r\nConnection: close\r\n" +
+               "icy-metadata: 1\r\ntransferMode.dlna.org: Streaming\n\r\nHEAD / HTTP/1.1\r\n" +
+               "Host: #{address}\r\n" + "User-Agent: DirbleScrobbler\n\r\n";
     end
 
     def disconnect

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -39,7 +39,11 @@ module Shoutout
       # Read status line
       status_line = @socket.gets
       print status_line.inspect
-      status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
+      begin
+        status_code = status_line.match(/\AICY ([0-9]{3})/)[1].to_i
+      rescue NoMethodError
+        status_code = 200
+      end
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -156,7 +156,7 @@ module Shoutout
           metadata_length = data.unpack("c")[0] * 16
           next if metadata_length == 0
 
-          data = @socket.read(metadata_interval) || raise(EOFError)
+          data = @socket.read(metadata_length) || raise(EOFError)
           raw_metadata = data.unpack("A*")[0]
           print "\r\n\r\n metadata?: " + raw_metadata + "\r\n\r\n"
           @metadata = Metadata.parse(raw_metadata)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -158,6 +158,7 @@ module Shoutout
 
           data = @socket.read(metadata_interval) || raise(EOFError)
           raw_metadata = data.unpack("A*")[0]
+          print "\r\n\r\n metadata?: " + raw_metadata + "\r\n\r\n"
           @metadata = Metadata.parse(raw_metadata)
           
           report_metadata_change(@metadata)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -31,7 +31,7 @@ module Shoutout
 
     def connect
       return false if @connected
-
+      print "conencting to #{@url}"
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
       @socket.puts send_header_request(uri.path, uri.host)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -55,8 +55,12 @@ module Shoutout
 
       if status_code != false && status_code >= 300 && status_code < 400 && headers[:location]
         disconnect
-
+        
+        if @url_retry != nil
+          raise(SocketError) if @url == @url_retry
+        end
         @url = headers[:location].to_s
+        @url_retry = headers[:location].to_s
 
         return connect
       end

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,16 +38,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.gets
-      print status_line.inspect
-      begin
-        status_code = status_line.match(/\AICY ([0-9]{3})/)[1].to_i
-      rescue NoMethodError
-        begin
-            status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
-        rescue NoMethodError
-            status_code = 200
-        end
-      end
+      status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)[2].to_i
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,6 +38,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.read(15)
+      print "\r\n\r\n" + status_line + "\r\n\r\n"
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -35,7 +35,7 @@ module Shoutout
       uri = URI.parse(@url)
       begin 
         Timeout.timeout(3) do
-            TCPSocket.new(uri.host, uri.port)
+            @socket = TCPSocket.new(uri.host, uri.port)
         end
       rescue Timeout::Error
         return false

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -37,7 +37,7 @@ module Shoutout
       @socket.write(send_header_request(uri.path, uri.host))
 
       # Read status line
-      status_line = @socket.read()
+      status_line = @socket.gets
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -149,13 +149,14 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          data = @socket.read(metadata_interval) || raise(EOFError)
+          newmeta_int = metadata_interval - 512
+          data = @socket.read(newmeta_int) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)
           metadata_length = data.unpack("c")[0] * 16
           next if metadata_length == 0
 
-          data = @socket.read(metadata_length) || raise(EOFError)
+          data = @socket.read(metadata_interval) || raise(EOFError)
           raw_metadata = data.unpack("A*")[0]
           @metadata = Metadata.parse(raw_metadata)
           

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -112,10 +112,8 @@ module Shoutout
       end
 
       def read_metadata
-        @count = 0
-        while @connected && @count < 3
+        while @connected
           # Skip audio data
-          @count = @count + 1
           data = @socket.read(metadata_interval) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)
@@ -127,9 +125,6 @@ module Shoutout
           @metadata = Metadata.parse(raw_metadata)
           
           report_metadata_change(@metadata)
-        end
-        if @count == 2
-            disconnect
         end
       rescue Errno::EBADF, IOError => e
         # Connection lost

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -109,7 +109,7 @@ module Shoutout
       def read_headers
         raw_headers = ""
         while line = @socket.gets
-          break if line.chomp == ""
+          break if line == "\r\n"
           raw_headers << line
         end
         @headers = Headers.parse(raw_headers)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,7 +34,7 @@ module Shoutout
 
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.write send_header_request(uri.path)
+      @socket.puts send_header_request(uri.path)
 
       # Read status line
       status_line = @socket.gets

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -32,12 +32,12 @@ module Shoutout
     def connect
       return false if @connected
       uri = URI.parse(@url)
-      
-      @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.puts send_header_request(uri.path, uri.host)
+
+      @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
+      @socket.write(send_header_request(uri.path, uri.host))
 
       # Read status line
-      status_line = @socket.gets
+      status_line = @socket.read(20)
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -140,8 +140,10 @@ module Shoutout
     private
       def read_headers
         raw_headers = ""
-        while line = @socket.gets
-          break if line == "\r\n"
+        lines = @socket.read(1624)
+        lines = lines.split("\r\n")
+        lines.each do |line|
+          break if line == "\r\n" || line == ""
           raw_headers << line
         end
         @headers = Headers.parse(raw_headers)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,7 +34,11 @@ module Shoutout
       uri = URI.parse(@url)
 
       @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
-      headersget = send_header_request(uri.path, uri.host)
+      path = uri.path
+      if path == nil || path == ""
+        path = "/"
+      end
+      headersget = send_header_request(path, uri.host)
       print "request HEADERS: #{headersget.inspect}"
       @socket.write(headersget)
       @first = true

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,6 +38,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.read(20)
+      print status_line
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -141,11 +142,13 @@ module Shoutout
       def read_headers
         raw_headers = ""
         lines = @socket.read(1624)
+        print "lines: " + lines
         lines = lines.split("\r\n")
         lines.each do |line|
           break if line == "\r\n" || line == ""
           raw_headers << line
         end
+        print "headers: " + raw_headers
         @headers = Headers.parse(raw_headers)
       end
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -92,7 +92,7 @@ module Shoutout
 
       @socket.close if @socket && !@socket.closed?
       @socket = nil
-
+      Thread.kill(@read_metadata_thread)
       true
     end
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,7 +38,6 @@ module Shoutout
 
       # Read status line
       status_line = @socket.read(15)
-      print status_line
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -141,8 +140,8 @@ module Shoutout
     private
       def read_headers
         lines = @socket.read(1624)
-        print "lines: " + lines
         @headers = Headers.parse(lines)
+        print @headers.inspect + "\r\n\r\n"
       end
 
       def read_metadata

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -35,7 +35,7 @@ module Shoutout
 
       @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
       @socket.write(send_header_request(uri.path, uri.host))
-
+      @first = true
       # Read status line
       status_line = @socket.read(15)
       if status_line != nil
@@ -147,7 +147,12 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          newmeta_int = metadata_interval - 256
+          if(@first == true)
+            newmeta_int = metadata_interval - 256
+            @first = false
+          else
+            newmeta_int = metadata_interval
+          end
           data = @socket.read(newmeta_int) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -56,7 +56,7 @@ module Shoutout
       if status_code != false && status_code >= 300 && status_code < 400 && headers[:location]
         disconnect
 
-        @url = URI.join(uri, headers[:location]).to_s
+        @url = headers[:location].to_s
 
         return connect
       end

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -37,7 +37,7 @@ module Shoutout
       @socket.write(send_header_request(uri.path, uri.host))
 
       # Read status line
-      status_line = @socket.read(20)
+      status_line = @socket.read(15)
       print status_line
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
@@ -140,16 +140,9 @@ module Shoutout
 
     private
       def read_headers
-        raw_headers = ""
         lines = @socket.read(1624)
         print "lines: " + lines
-        lines = lines.split("\r\n")
-        lines.each do |line|
-          break if line == "\r\n" || line == ""
-          raw_headers << line
-        end
-        print "headers: " + raw_headers
-        @headers = Headers.parse(raw_headers)
+        @headers = Headers.parse(lines)
       end
 
       def read_metadata

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -141,7 +141,7 @@ module Shoutout
     end
 
     def send_header_request(address, host)
-        return "GET #{address} HTTP/1.1\r\nAccept-Encoding: identity\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nConnection: close\r\nUser-Agent: iTunes/9.1.1\r\n\r\n";
+        return "GET #{address} HTTP/1.1\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nUser-Agent: DirbleScrobbler/1.1 (dirble.com)\r\n\r\n";
     end
 
     private

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -40,11 +40,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.gets
-      begin
-        status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
-      rescue NoMethodError
-        status_code = 200 #custom streams who doesn't send icy 200 OK will be 200 as default, if not it will send a exception anyway
-      end
+      status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -93,6 +93,9 @@ module Shoutout
       @socket.close if @socket && !@socket.closed?
       @socket = nil
       Thread.kill(@read_metadata_thread)
+      if @last_metadata_change_thread != nil
+        Thread.kill(@last_metadata_change_thread)
+      end
       true
     end
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -64,6 +64,14 @@ module Shoutout
 
         return connect
       end
+      
+      if status_code != false
+          unless status_code >= 200 && status_code < 300
+            disconnect
+    
+            return false
+          end
+      end
 
 
       unless metadata_interval

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -39,12 +39,10 @@ module Shoutout
         path = "/"
       end
       headersget = send_header_request(path, uri.host)
-      print "request HEADERS: #{headersget.inspect}"
       @socket.write(headersget)
       @first = true
       # Read status line
       status_line = @socket.read(15)
-      print "Status: #{status_line}"
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -54,12 +52,10 @@ module Shoutout
       else
         status_code = false
       end
-      print "Status code: #{status_code}"
 
       @connected = true
 
       read_headers
-      print "HEADERS: #{headers.inspect}"
 
       if status_code != false && status_code >= 300 && status_code < 400 && headers[:location]
         disconnect
@@ -147,7 +143,7 @@ module Shoutout
     end
 
     def send_header_request(address, host)
-        return "GET #{address} HTTP/1.1\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nUser-Agent: DirbleScrobbler/1.1 (dirble.com)\r\nAccept: */*\r\n\r\n";
+        return "GET #{address} HTTP/1.1\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nUser-Agent: iTunes/9.1.1\r\nAccept: */*\r\n\r\n";
     end
 
     private

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,9 +34,7 @@ module Shoutout
 
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
-      @socket.puts "GET #{uri.path} HTTP/1.0"
-      @socket.puts "icy-metadata: 1"
-      @socket.puts
+      @socket.puts send_header_request(uri.path)
 
       @connected = true
 
@@ -99,6 +97,12 @@ module Shoutout
       report_metadata_change(@metadata) if defined?(@metadata)
 
       true
+    end
+
+    def send_header_request(address)
+        return "GET / HTTP/1.1\r\nHost: #{address}\r\nConnection: close\r\n" +
+               "icy-metadata: 1\r\ntransferMode.dlna.org: Streaming\n\r\nHEAD / HTTP/1.1\r\n" +
+               "Host: #{address}\r\n" + "User-Agent: DirbleScrobbler\n\r\n";
     end
 
     private

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -149,7 +149,7 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          newmeta_int = metadata_interval - 512
+          newmeta_int = metadata_interval - 256
           data = @socket.read(newmeta_int) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -35,12 +35,13 @@ module Shoutout
       uri = URI.parse(@url)
       @socket = TCPSocket.new(uri.host, uri.port)
       @socket.puts "GET #{uri.path} HTTP/1.0"
-      @socket.puts "Icy-MetaData: 1"
+      @socket.puts "User-Agent: iTunes/9.1.1"
+      @socket.puts "icy-metadata: 1"
       @socket.puts
 
       # Read status line
       status_line = @socket.gets
-      status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
+      status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -40,7 +40,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.gets
-      status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
+      status_code = status_line.match(/ICY ([0-9]{3})/)[1].to_i
 
       @connected = true
 

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -149,7 +149,8 @@ module Shoutout
       def read_metadata
         while @connected
           # Skip audio data
-          data = @socket.read(metadata_interval) || raise(EOFError)
+          newmeta_int = metadata_interval - 256
+          data = @socket.read(newmeta_int) || raise(EOFError)
 
           data = @socket.read(1) || raise(EOFError)
           metadata_length = data.unpack("c")[0] * 16

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -1,4 +1,3 @@
-require 'tcp_timeout'
 module Shoutout
   class Stream
     include QuickAccess

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -34,7 +34,9 @@ module Shoutout
       uri = URI.parse(@url)
 
       @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
-      @socket.write(send_header_request(uri.path, uri.host))
+      headersget = send_header_request(uri.path, uri.host)
+      print "request HEADERS: #{headersget.inspect}"
+      @socket.write(headersget)
       @first = true
       # Read status line
       status_line = @socket.read(15)
@@ -141,7 +143,7 @@ module Shoutout
     end
 
     def send_header_request(address, host)
-        return "GET #{address} HTTP/1.1\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nUser-Agent: DirbleScrobbler/1.1 (dirble.com)\r\n\r\n";
+        return "GET #{address} HTTP/1.1\r\nIcy-Metadata: 1\r\nHost: #{host}\r\nUser-Agent: DirbleScrobbler/1.1 (dirble.com)\r\nAccept: */*\r\n\r\n";
     end
 
     private

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,6 +38,7 @@ module Shoutout
 
       # Read status line
       status_line = @socket.gets
+      print status_line.inspect
       status_code = status_line.match(/\AHTTP\/([0-9]\.[0-9]) ([0-9]{3})/)[2].to_i
 
       @connected = true

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -38,6 +38,7 @@ module Shoutout
       @first = true
       # Read status line
       status_line = @socket.read(15)
+      print "Status: #{status_line}"
       if status_line != nil
         status_code = status_line.match(/\A(HTTP\/[0-9]\.[0-9]|ICY) ([0-9]{3})/)
         if status_code != nil
@@ -47,11 +48,12 @@ module Shoutout
       else
         status_code = false
       end
-
+      print "Status code: #{status_code}"
 
       @connected = true
 
       read_headers
+      print "HEADERS: #{headers.inspect}"
 
       if status_code != false && status_code >= 300 && status_code < 400 && headers[:location]
         disconnect

--- a/lib/shoutout/stream.rb
+++ b/lib/shoutout/stream.rb
@@ -33,8 +33,8 @@ module Shoutout
       return false if @connected
       uri = URI.parse(@url)
       
-      @socket = TCPTimeout::TCPSocket.new(uri.host, uri.port, connect_timeout: 10, write_timeout: 9)
-      @socket.write(send_header_request(uri.path, uri.host))
+      @socket = TCPSocket.new(uri.host, uri.port)
+      @socket.puts send_header_request(uri.path, uri.host)
 
       # Read status line
       status_line = @socket.gets

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "tcp_timeout"
 end

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") + %w(LICENSE README.md Rakefile Gemfile)
   s.test_files    = Dir.glob("spec/**/*")
   s.require_path  = "lib"
+  s.add_runtime_dependency "tcp_timeout"
   
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "tcp_timeout"
 end

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") + %w(LICENSE README.md Rakefile Gemfile)
   s.test_files    = Dir.glob("spec/**/*")
   s.require_path  = "lib"
-  s.add_runtime_dependency "tcp_timeout"
+  s.add_runtime_dependency "tcp_timeout", '>= 0', '>= 0'
   
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") + %w(LICENSE README.md Rakefile Gemfile)
   s.test_files    = Dir.glob("spec/**/*")
   s.require_path  = "lib"
-  s.add_dependency("tcp_timeout")
   
+  s.add_runtime_dependency     "tcp_timeout", "~> 0.1", ">= 0.1.1"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
 end

--- a/shoutout.gemspec
+++ b/shoutout.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") + %w(LICENSE README.md Rakefile Gemfile)
   s.test_files    = Dir.glob("spec/**/*")
   s.require_path  = "lib"
-  s.add_runtime_dependency "tcp_timeout", '>= 0', '>= 0'
+  s.add_dependency("tcp_timeout")
   
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This is similar to the first pull request with some difference how to handle the status code, with support for not going in a infinite redirect loop and to set the special headers.

The headers that was testdata in first PR will be included in this pull request. some streams seems to look for user-agent and Host to allow or deny the metadata, somehow. This made it work for some custom streams.

I had some streams that had 301 redirects which the new status code fix works for. I needed to check if status_code exist, and if it exist I check if it is redirect, and connect to the header location instead. If not I just run as normal. I had 2 streams that went into a redirect loop which is why I raise a exception if it is still the same url after one redirect, to stop the infinite loop.
